### PR TITLE
first basic implementaion of 'absorption layer'-parameter for specular material

### DIFF
--- a/sources/indigo/export/materials/Base.py
+++ b/sources/indigo/export/materials/Base.py
@@ -71,6 +71,7 @@ class MaterialBase(xml_builder):
         op.update(self.BlendChannel())
         op.update(self.TransmittanceChannel())
         op.update(self.AbsorptionChannel())
+        op.update(self.AbsorptionLayerChannel())
         op.update(self.FresnelScaleChannel())
         
         if len(self.found_textures) > 0:
@@ -212,6 +213,8 @@ class MaterialBase(xml_builder):
         return {}
     def AbsorptionChannel(self):
         return {}
+    def AbsorptionLayerChannel(self):
+        return {}
     def FresnelScaleChannel(self):
         return {}
 
@@ -292,6 +295,14 @@ class AbsorptionChannelMaterial(object):
     #['caoting']
     def AbsorptionChannel(self):
         return self.get_channel(self.material_group.indigo_material_absorption, 'absorption', 'absorption')
+
+class AbsorptionLayerChannelMaterial(object):
+    #['specular']
+    def AbsorptionLayerChannel(self):
+        if self.material_group.indigo_material_absorption_layer.absorption_layer_enabled:
+            return self.get_channel(self.material_group.indigo_material_absorption_layer, 'absorption_layer_transmittance', 'absorption_layer')
+        else:
+            return {}
         
 class FresnelScaleChannelMaterial(object):
     #['phong']

--- a/sources/indigo/export/materials/Specular.py
+++ b/sources/indigo/export/materials/Specular.py
@@ -25,7 +25,7 @@
 # ***** END GPL LICENCE BLOCK *****
 #
 from indigo.export import xml_builder
-from indigo.export.materials.Base        import EmissionChannelMaterial, BumpChannelMaterial, NormalChannelMaterial, DisplacementChannelMaterial, ExponentChannelMaterial, MaterialBase
+from indigo.export.materials.Base        import EmissionChannelMaterial, BumpChannelMaterial, NormalChannelMaterial, DisplacementChannelMaterial, ExponentChannelMaterial, AbsorptionLayerChannelMaterial, MaterialBase
 from indigo.export.materials.spectra    import rgb, uniform
 
 class SpecularMedium(xml_builder):
@@ -103,6 +103,7 @@ class SpecularMedium(xml_builder):
         return fmt
 
 class SpecularMaterial(
+    AbsorptionLayerChannelMaterial,
     EmissionChannelMaterial,
     BumpChannelMaterial,
     NormalChannelMaterial,

--- a/sources/indigo/panels/material.py
+++ b/sources/indigo/panels/material.py
@@ -142,6 +142,19 @@ class indigo_ui_material_absorption(indigo_ui_material_subpanel):
         self.layout.prop(context.material.indigo_material.indigo_material_absorption, "absorption_enabled", text="")
 
 @IndigoAddon.addon_register_class
+class indigo_ui_material_absorption(indigo_ui_material_subpanel):
+    bl_label = 'Absorption Layer'
+    
+    INDIGO_COMPAT = PROPERTY_GROUP_USAGE['absorption_layer']
+    
+    display_property_groups = [
+        ( ('material', 'indigo_material'), 'indigo_material_absorption_layer' )
+    ]
+    
+    def draw_header(self, context):
+        self.layout.prop(context.material.indigo_material.indigo_material_absorption_layer, "absorption_layer_enabled", text="")
+
+@IndigoAddon.addon_register_class
 class indigo_ui_material_diffuse(indigo_ui_material_subpanel):
     bl_label = 'Material Diffuse Settings'
     

--- a/sources/indigo/properties/material.py
+++ b/sources/indigo/properties/material.py
@@ -50,6 +50,7 @@ PROPERTY_GROUP_USAGE = {
     'phong': {'phong'},
     'coating': {'coating'},
     'absorption': {'coating'},
+    'absorption_layer': {'specular'},
     'doublesidedthin': {'doublesidedthin'},
     'transmittance': {'doublesidedthin'},
     'diffuse': {'diffuse'},
@@ -1060,6 +1061,19 @@ class indigo_material_absorption(indigo_material_feature):
     visibility    = Cha_Absorption.visibility
     enabled        = Cha_Absorption.enabled
     properties    = Cha_Absorption.properties
+    
+    def get_output(self, obj, indigo_material, blender_material, scene):
+        return []
+
+Cha_AbsorptionLayer  = MaterialChannel('absorption_layer', spectrum=True, texture=True,  shader=True,  switch=True, spectrum_types={'rgb':True, 'rgbgain':True, 'uniform':True, 'blackbody': True, 'rgb_default':(0.0,0.0,0.0)}, label='Absorption Layer')
+
+@IndigoAddon.addon_register_class
+class indigo_material_absorption_layer(indigo_material_feature):
+    
+    controls    = Cha_AbsorptionLayer.controls
+    visibility    = Cha_AbsorptionLayer.visibility
+    enabled        = Cha_AbsorptionLayer.enabled
+    properties    = Cha_AbsorptionLayer.properties
     
     def get_output(self, obj, indigo_material, blender_material, scene):
         return []


### PR DESCRIPTION
first basic implementation of the 'absorption layer' feature for specular / glossy material in blender ('absorption_layer_transmittance' parameter in indigo)

currently not supported: 
 - peak, tabulated, uniform 

![absorptionlayer](https://cloud.githubusercontent.com/assets/13567806/9550645/cb75c446-4dac-11e5-91cf-aae40f5edf66.png)
