### PR TITLE
Updated Render Settings

### DIFF
--- a/sources/indigo_exporter/panels/render.py
+++ b/sources/indigo_exporter/panels/render.py
@@ -28,8 +28,28 @@ class INDIGO_PT_ui_render_engine_settings(bpy.types.Panel):
             sc.prop(indigo_engine, 'bidir')
             sc.prop(indigo_engine, 'metro')
             
+            if not indigo_engine.gpu:
+                box = col.box()
+                sub = box.column()
+                sub.prop(indigo_engine, 'max_depth')
+
+            if indigo_engine.metro:
+                col.label(text="Metropolis Settings:")
+                box = col.box()
+                sub = box.column()
+                sub.prop(indigo_engine, 'large_mutation_prob')
+                sub.prop(indigo_engine, 'max_change')
+                sub.prop(indigo_engine, 'max_num_consec_rejections')
+
             sc = row.column()
             sc.prop(indigo_engine, 'shadow')
+
+        if indigo_engine.gpu:
+            col.label(text="GPU Settings:")
+            box = col.box()
+            sub = box.column()
+            sub.prop(indigo_engine, 'gpu_max_depth')
+            sub.prop(indigo_engine, 'compress_textures')
             
         col.separator()
         
@@ -59,11 +79,23 @@ class INDIGO_PT_ui_render_engine_settings(bpy.types.Panel):
                 sb = sub.row(align=True)
                 sb.prop(indigo_engine, 'ds_filter_blur', text="Blur")
                 sb.prop(indigo_engine, 'ds_filter_ring', text="Ring")
-                sb.prop(indigo_engine, 'ds_filter_radius', text="Radius")
-        
-        row = layout.row()
-        row.prop(indigo_engine, 'motionblur')
-        row.prop(indigo_engine, 'foreground_alpha')
+                sb.prop(indigo_engine, 'ds_filter_radius', text="Radius")     
+
+        col.label(text="Denoising Settings:")
+        box = col.box()
+        sub = box.column()
+        row = sub.row()
+        sc = row.column()
+        sc.prop(indigo_engine, 'optimise_for_denoising')
+        sc.prop(indigo_engine, 'denoise')
+
+        col.label(text="Misc. Settings:")
+        box = col.box()
+        sub = box.column()
+        row = sub.row()
+        sc = row.column()
+        sc.prop(indigo_engine, 'motionblur')
+        sc.prop(indigo_engine, 'foreground_alpha')    
         
         col = layout.column()
         col.separator()

--- a/sources/indigo_exporter/properties/render_settings.py
+++ b/sources/indigo_exporter/properties/render_settings.py
@@ -184,6 +184,61 @@ properties = [
         'default': False
     },
     {
+        'type': 'int',
+        'attr': 'gpu_max_depth',
+        'name': 'GPU Max Depth',
+        'description': 'Set the maximum number of ray bounces when doing openCL rendering.',
+        'default': 8,
+        'min': 4,
+        'soft_min': 8,
+        'max': 100,
+        'soft_max': 32
+    },
+    {
+        'type': 'int',
+        'attr': 'max_depth',
+        'name': 'Max Depth',
+        'description': 'Set the maximum number of ray bounces.',
+        'default': 10000,
+        'min': 0,
+        'soft_min': 2000,
+        'max': 100000,
+        'soft_max': 100000
+    },
+    {
+        'type': 'float',
+        'attr': 'large_mutation_prob',
+        'name': 'Large Mutation Probability',
+        'description': 'Probability of selecting a large mutation type',
+        'default': 0.4,
+        'min': 0,
+        'soft_min': 0.2,
+        'max': 1,
+        'soft_max': 0.8,
+    },
+    {
+        'type': 'float',
+        'attr': 'max_change',
+        'name': 'Max Change',
+        'description': 'Radius of the perturbation mutation distribution',
+        'default': 0.01,
+        'min': 0,
+        'soft_min': 0.01,
+        'max': 1,
+        'soft_max': 0.04,
+    },
+    {
+        'type': 'int',
+        'attr': 'max_num_consec_rejections',
+        'name': 'MNCR',
+        'description': 'Maximum number of consecutive rejection of tentative new samples when Metropolis-Hastings transport is used. Note that any non-infinite number technically causes biased sampling.',
+        'default': 1000,
+        'min': 1,
+        'soft_min': 100,
+        'max': 100000,
+        'soft_max': 5000
+    },
+    {
         # legacy
         'type': 'bool',
         'attr': 'alpha_mask',
@@ -209,7 +264,7 @@ properties = [
         'type': 'bool',
         'attr': 'bidir',
         'name': 'Bi-Directional',
-        'description': 'Enable Bi-Directional Tracing',
+        'description': 'Enable Bi-Directional Path Tracing',
         'default': True
     },
     {
@@ -225,6 +280,31 @@ properties = [
         'name': 'Motion Blur',
         'description': 'Enable Motion Blur',
         'default': False
+    },
+    {
+        'type': 'bool',
+        'attr': 'optimise_for_denoising',
+        'name': 'Otimise For Denoising',
+        'description': 'Enables albedo and normals channels, bucket rendering, and decorrelated pixel sampling for optimal denoising',
+        'default': False
+    },
+    {
+        'type': 'bool',
+        'attr': 'denoise',
+        'name': 'Denoise',
+        'description': 'Enables denoising for every image update. Not recommended for high resolutions and higher supersampling levels',
+        'default': False
+    },
+    {
+        'type': 'int',
+        'attr': 'denoising_max_memory_mb',
+        'name': 'Max Memory for Denoising',
+        'description': 'Max memory limit for denoising',
+        'default': 6000,
+        'min': 6000,
+        'soft_min': 6000,
+        'max': 16000,
+        'soft_max': 12000
     },
     {
         'type': 'bool',
@@ -477,6 +557,17 @@ properties = [
             ('master', 'Master', 'Start Indigo as a Master node (doesn\'t render)'),
             ('working_master', 'Working Master', 'Start Indigo as a Working Master node'),
             # ('manual', 'Manual', 'Connect manually to a running slave')
+        ]
+    },
+     {
+        'type': 'enum',
+        'attr': 'compress_textures',
+        'name': 'Compress Textures',
+        'default': '0',
+        'items': [
+            ('0', 'Off', 'No compression'),
+            ('1', 'All, except bump & normal maps', 'Compress all textures except bump and normal maps'),
+            ('2', 'All', 'Compress all textures'),
         ]
     },
     {
@@ -812,10 +903,19 @@ class Indigo_Engine_Properties(bpy.types.PropertyGroup, export.xml_builder):
                 'render_foreground_alpha': 'foreground_alpha',
                 'max_contribution': 'max_contribution',
                 'clamp_contributions': 'clamp_contributions',
+                'optimise_for_denoising': 'optimise_for_denoising',
+                'denoise': 'denoise',
                 
                 'shadow_pass': 'shadow',
 
                 'gpu': 'gpu',
+                'gpu_max_depth': 'gpu_max_depth',
+                'max_depth': 'max_depth',
+                'max_change': 'max_change',
+                'max_num_consec_rejections': 'max_num_consec_rejections',
+
+                'compress_textures': 'compress_textures',
+                
 
                 'beauty_channel': 'channel_beauty',
                 'albedo_channel': 'channel_albedo',


### PR DESCRIPTION
Added GPU Max Path Depth when Path (GPU) or Custom -> GPU are enabled. Added Texture Compression  selection for GPU render modes. Added Metropolis specific settings when Custom->Metropolis is enabled.
1. Large Mutation probabili9ty
2. Max Change
3. MNCR

Added Mex Depth to CPU render modes when Custom is enabled.

Adde Denoising Settings:
1. Optimize for Denoising
2. Denoise

Moved Motion Blur and Foreground Alpha into Misc. Settings box.